### PR TITLE
mongodb-2.2 cartridge no longer available

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ Creating the app
 
 Adding a mongodb cartridge
 
-    rhc cartridge add --app flock mongodb-2.2
+    rhc cartridge add --app flock mongodb-2.4
 
 Exporting the registrations as JSON
 


### PR DESCRIPTION
mongodb-2.2 cartridge is no longer available in OpenShift, but mongodb-2.4.
